### PR TITLE
robotkernel: add webdriver persistence for RPA.Browser

### DIFF
--- a/src/robotkernel/kernel.py
+++ b/src/robotkernel/kernel.py
@@ -14,6 +14,7 @@ from robotkernel.listeners import AppiumConnectionsListener
 from robotkernel.listeners import JupyterConnectionsListener
 from robotkernel.listeners import RobotKeywordsIndexerListener
 from robotkernel.listeners import RobotVariablesListener
+from robotkernel.listeners import RpaBrowserConnectionsListener
 from robotkernel.listeners import SeleniumConnectionsListener
 from robotkernel.listeners import WhiteLibraryListener
 from robotkernel.monkeypatches import inject_libdoc_ipynb_support
@@ -243,6 +244,7 @@ class RobotKernel(DisplayKernel):
 
             # Configure listeners
             listeners = [
+                RpaBrowserConnectionsListener(self.robot_connections),
                 SeleniumConnectionsListener(self.robot_connections),
                 JupyterConnectionsListener(self.robot_connections),
                 AppiumConnectionsListener(self.robot_connections),

--- a/src/robotkernel/listeners.py
+++ b/src/robotkernel/listeners.py
@@ -250,6 +250,30 @@ class SeleniumConnectionsListener:
             pass
 
 
+class RpaBrowserConnectionsListener:
+    ROBOT_LISTENER_API_VERSION = 2
+
+    def __init__(self, drivers: list):
+        self.drivers = drivers
+
+    # noinspection PyUnusedLocal,PyProtectedMember
+    def end_suite(self, name, attributes):
+        try:
+            instance = BuiltIn().get_library_instance("RPA.Browser")
+            clear_drivers(self.drivers, "RPA.Browser")
+            self.drivers.extend(get_webdrivers(instance._drivers, "RPA.Browser"))
+        except RuntimeError:
+            pass
+
+    # noinspection PyUnusedLocal,PyProtectedMember
+    def start_suite(self, name, attributes):
+        try:
+            instance = BuiltIn().get_library_instance("RPA.Browser")
+            set_webdrivers(self.drivers, instance._drivers, "RPA.Browser")
+        except RuntimeError:
+            pass
+
+
 class JupyterConnectionsListener:
     ROBOT_LISTENER_API_VERSION = 2
 


### PR DESCRIPTION
This is not very optimal, but works as a hotfix to persist webdrivers when using browser keywords in multiple cells.