### PR TITLE
Add restart property for reply to shutdown_request

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = robotkernel
-version = 10.3.2
+version = 10.3.3
 description = A Jupyter kernel for interactive acceptance-test-driven development with the Robot Framework
 long_description = file: README.rst, CHANGELOG.rst
 url = https://github.com/robocorp/robocode-kernel

--- a/src/robotkernel/kernel.py
+++ b/src/robotkernel/kernel.py
@@ -108,6 +108,11 @@ class RobotKernel(DisplayKernel):
                 driver["instance"].quit()
         self.robot_connections = []
 
+        reply_content = {
+            "restart": restart,
+        }
+        return reply_content
+
     def do_complete(self, code, cursor_pos):
         context = detect_robot_context(code, cursor_pos)
         cursor_pos = cursor_pos is None and len(code) or cursor_pos


### PR DESCRIPTION
Updated kernel reply to shutdown_request according to [Kernel shutdown messages](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-shutdown)